### PR TITLE
Update COOKIE_DOMAIN to persist authentication

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -82,6 +82,7 @@ define('WP_ALLOW_MULTISITE', true);
 define('MULTISITE', true);
 define('SUBDOMAIN_INSTALL', false);
 define('DOMAIN_CURRENT_SITE', env('DOMAIN_CURRENT_SITE'));
+define('COOKIE_DOMAIN', '.' . env('DOMAIN_CURRENT_SITE'));
 define('PATH_CURRENT_SITE', '/');
 define('SITE_ID_CURRENT_SITE', 1);
 define('BLOG_ID_CURRENT_SITE', 1);


### PR DESCRIPTION
This makes sure the `COOKIE_DOMAIN` constant is set to something like `.textopress.com`. This wasn't happening for `staging.textopress.com` so this just makes sure it happens.